### PR TITLE
Add support for the arduino due board, with example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 Cargo.lock
+image.bin
 svd2rust-*-warnings.log

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+    "boards/*",
     "hal",
     "pac/atsam3*",
 ]

--- a/boards/arduino_due/.cargo/config
+++ b/boards/arduino_due/.cargo/config
@@ -1,0 +1,30 @@
+[target.thumbv7m-none-eabi]
+# uncomment this to make `cargo run` execute programs on QEMU
+# runner = "qemu-system-arm -cpu cortex-m3 -machine lm3s6965evb -nographic -semihosting-config enable=on,target=native -kernel"
+
+[target.'cfg(all(target_arch = "arm", target_os = "none"))']
+# uncomment ONE of these three option to make `cargo run` start a GDB session
+# which option to pick depends on your system
+# runner = "arm-none-eabi-gdb -q -x openocd.gdb"
+# runner = "gdb-multiarch -q -x openocd.gdb"
+# runner = "gdb -q -x openocd.gdb"
+
+rustflags = [
+  # LLD (shipped with the Rust toolchain) is used as the default linker
+  "-C", "link-arg=-Tlink.x",
+
+  # if you run into problems with LLD switch to the GNU linker by commenting out
+  # this line
+  #"-C", "linker=arm-none-eabi-ld",
+
+  # if you need to link to pre-compiled C libraries provided by a C toolchain
+  # use GCC as the linker by commenting out both lines above and then
+  # uncommenting the three lines below
+  # "-C", "linker=arm-none-eabi-gcc",
+  # "-C", "link-arg=-Wl,-Tlink.x",
+  # "-C", "link-arg=-nostartfiles",
+]
+
+[build]
+target = "thumbv7m-none-eabi"    # Cortex-M3
+

--- a/boards/arduino_due/Cargo.toml
+++ b/boards/arduino_due/Cargo.toml
@@ -1,0 +1,44 @@
+[package]
+edition = "2018"
+name = "arduino_due"
+version = "0.2.0"
+authors = ["Will Page <compenguy@gmail.com>"]
+description = "Board Support crate for the Arduino Due"
+keywords = ["no-std", "arm", "cortex-m", "embedded-hal", "arduino", "due"]
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/compenguy/atsam3xa"
+readme = "README.md"
+
+[dependencies]
+cortex-m = "~0.6"
+embedded-hal = "~0.2.3"
+nb = "~0.1"
+paste = "1.0"
+
+[dependencies.cortex-m-rt]
+version = "~0.6.12"
+optional = true
+
+[dependencies.panic-halt]
+version = "~0.2"
+optional = true
+
+[dependencies.atsam3xa-hal]
+path = "../../hal"
+version = "~0.1"
+default-features = false
+features = ["sam3x8e"]
+
+
+[features]
+# ask the HAL to enable atsamd3x8e support
+default = ["rt", "panic_halt", "atsam3xa-hal/sam3x8e", "sam3x8e"]
+rt = ["cortex-m-rt", "atsam3xa-hal/sam3x8e-rt"]
+# Puts a breakpoint on `rust_begin_unwind` to catch panics
+panic_halt = ["panic-halt"]
+sam3x8e = ["sam3_e"]
+sam3_e = []
+
+[[example]]
+name = "blinky_basic"
+

--- a/boards/arduino_due/Makefile.toml
+++ b/boards/arduino_due/Makefile.toml
@@ -1,0 +1,27 @@
+[env]
+TARGET_NAME = "blinky_basic"
+IMAGE_NAME = "image.bin"
+SERDEV_LINUX = "ttyACM0"
+SERDEV_WINDOWS = "com8"
+
+[tasks.image]
+install_crate = "cargo-binutils"
+command = "cargo"
+args = ["objcopy", "--example", "${TARGET_NAME}", "--target", "thumbv7m-none-eabi", "--release", "--", "--output-target=binary", "${IMAGE_NAME}"]
+
+[tasks.init_serial]
+linux_alias = "linux_init_serial"
+windows_alias = "windows_init_serial"
+
+[tasks.linux_init_serial]
+command = "stty"
+args = ["-F", "/dev/${SERDEV_LINUX}", "speed", "1200", "cs8", "-cstopb", "-parenb"]
+
+[tasks.windows_init_serial]
+command = "mode"
+args = ["${SERDEV_WINDOWS}:1200,n,8,1"]
+
+[tasks.flash]
+command = "bossac"
+args = ["-p", "${SERDEV_LINUX}", "-e", "-w", "-v", "-b", "-R", "${IMAGE_NAME}"]
+dependencies = ["image", "init_serial"]

--- a/boards/arduino_due/README.md
+++ b/boards/arduino_due/README.md
@@ -1,0 +1,30 @@
+# Arduino Due Board Support Crate
+
+This crate provides a type-safe API for working with the [Arduino Due board](https://store.arduino.cc/arduino-due).
+
+## Examples
+### Blinky Basic
+#### Requirements
+ - Use `arduino-cli` to fetch `bossac` and the `arm-none-eabi` tools
+    - Download the latest release of [arduino-cli](https://github.com/arduino/arduino-cli/releases)
+    - Run `arduino-cli config init`
+    - Run `arduino-cli core install arduino:sam`
+    - Tools will be placed in `~/.arduino15/packages/arduino/...`
+ - Separately:
+    - Linux - typically available in distribution package repositories (Debian/Ubuntu: `bossa-cli`, `binutils-arm-none-eabi`)
+    - Windows:
+       - Arduino IDE installed
+          - samd package installed
+          - Now the arduino distribution contains bossac.exe in `ArduinoData/packages/arduino/tools/bossac/1.7.0/` add it to your path
+          - Probably best to install an example sketch via the IDE just to make sure everything is working
+       - arm-none-eabi tools installed, you need gcc and objcopy.
+ - thumbv7m-none-eabi rust target installed via `rustup target add thumbv7m-none-eabi`
+
+#### Steps
+```bash
+cargo build --release --example blinky_basic
+arm-none-eabi-objcopy -O binary target/thumbv7m-none-eabi/release/examples/blinky_basic target/blinky_basic.bin
+stty -F /dev/ttyACM0 speed 1200 cs8 -cstopb -parenb
+bossac -i -d -U true -i -e -w -v target/blinky_basic.bin -R
+```
+

--- a/boards/arduino_due/README.md
+++ b/boards/arduino_due/README.md
@@ -5,26 +5,32 @@ This crate provides a type-safe API for working with the [Arduino Due board](htt
 ## Examples
 ### Blinky Basic
 #### Requirements
- - Use `arduino-cli` to fetch `bossac` and the `arm-none-eabi` tools
+ - Use `arduino-cli` to fetch `bossac`
     - Download the latest release of [arduino-cli](https://github.com/arduino/arduino-cli/releases)
     - Run `arduino-cli config init`
     - Run `arduino-cli core install arduino:sam`
     - Tools will be placed in `~/.arduino15/packages/arduino/...`
  - Separately:
-    - Linux - typically available in distribution package repositories (Debian/Ubuntu: `bossa-cli`, `binutils-arm-none-eabi`)
+    - Linux - typically available in distribution package repositories (Debian/Ubuntu: `bossa-cli`)
     - Windows:
        - Arduino IDE installed
           - samd package installed
           - Now the arduino distribution contains bossac.exe in `ArduinoData/packages/arduino/tools/bossac/1.7.0/` add it to your path
           - Probably best to install an example sketch via the IDE just to make sure everything is working
-       - arm-none-eabi tools installed, you need gcc and objcopy.
  - thumbv7m-none-eabi rust target installed via `rustup target add thumbv7m-none-eabi`
 
 #### Steps
 ```bash
-cargo build --release --example blinky_basic
-arm-none-eabi-objcopy -O binary target/thumbv7m-none-eabi/release/examples/blinky_basic target/blinky_basic.bin
-stty -F /dev/ttyACM0 speed 1200 cs8 -cstopb -parenb
-bossac -i -d -U true -i -e -w -v target/blinky_basic.bin -R
+$ cargo install make
+$ cargo make flash
 ```
 
+The default example to build and flash is `blinky_basic`.  To select a
+different one, instead run:
+
+```bash
+$ cargo make --env TARGET_NAME=<example_name> flash
+```
+
+If the serial port name is wrong, the default can be overridden by setting
+the `SERDEV_LINUX` or `SERDEV_WINDOWS` environment variable.

--- a/boards/arduino_due/build.rs
+++ b/boards/arduino_due/build.rs
@@ -1,0 +1,33 @@
+//! This build script copies the `memory.x` file from the crate root into
+//! a directory where the linker can always find it at build time.
+//! For many projects this is optional, as the linker always searches the
+//! project root directory -- wherever `Cargo.toml` is. However, if you
+//! are using a workspace or have a more complicated build setup, this
+//! build script becomes required. Additionally, by requesting that
+//! Cargo re-run the build script whenever `memory.x` is changed,
+//! updating `memory.x` ensures a rebuild of the application with the
+//! new memory settings.
+
+/*
+#[cfg(any(feature = "atsam3a4c", feature = "atsam3x4c", feature = "atsam3x4e"))]
+const LINKER_SCRIPT: &str = "memory_sam3_4.x";
+#[cfg(any(feature = "atsam3a8c", feature = "atsam3x8c", feature = "atsam3x8e", feature = "atsam3x8h"))]
+*/
+const LINKER_SCRIPT: &str = "memory_sam3_8.x";
+
+fn main() {
+    // Put the linker script somewhere the linker can find it
+    let src_dir = std::path::PathBuf::from(
+        std::env::var_os("CARGO_MANIFEST_DIR").expect("Failed to locate project root directory"),
+    );
+    let link_dir = std::path::PathBuf::from(
+        std::env::var_os("OUT_DIR").expect("Failed to locate project build directory"),
+    );
+    std::fs::copy(src_dir.join(LINKER_SCRIPT), link_dir.join("memory.x"))
+        .expect("Failed copying linker script from project root to build directory");
+    println!("cargo:rustc-link-search={}", link_dir.to_string_lossy());
+
+    // Only re-run the build script when memory.x is changed,
+    // instead of when any part of the source code changes.
+    println!("{}", format!("cargo:rerun-if-changed={}", LINKER_SCRIPT));
+}

--- a/boards/arduino_due/examples/blinky_basic.rs
+++ b/boards/arduino_due/examples/blinky_basic.rs
@@ -6,10 +6,10 @@ use arduino_due as board;
 use board::entry;
 use board::prelude::*;
 
-use board::pac::{CorePeripherals, Peripherals};
 use board::hal::clock::SystemClocks;
 use board::hal::delay::Delay;
 use board::hal::watchdog::WdtBuilder;
+use board::pac::{CorePeripherals, Peripherals};
 
 #[entry]
 fn main() -> ! {

--- a/boards/arduino_due/examples/blinky_basic.rs
+++ b/boards/arduino_due/examples/blinky_basic.rs
@@ -1,0 +1,35 @@
+#![no_std]
+#![no_main]
+
+use arduino_due as board;
+
+use board::entry;
+use board::prelude::*;
+
+use board::pac::{CorePeripherals, Peripherals};
+use board::hal::clock::SystemClocks;
+use board::hal::delay::Delay;
+use board::hal::watchdog::WdtBuilder;
+
+#[entry]
+fn main() -> ! {
+    let peripherals = Peripherals::take().unwrap();
+    let core = CorePeripherals::take().unwrap();
+    let mut clocks = SystemClocks::new(peripherals.PMC, peripherals.SUPC);
+    let _ = WdtBuilder::from(peripherals.WDT).disable();
+    let pins = board::Pins::new(
+        peripherals.PIOA,
+        peripherals.PIOB,
+        peripherals.PIOC,
+        peripherals.PIOD,
+    );
+    let mut led = pins.led_l.into_push_pull_output();
+    let mut delay = Delay::new(core.SYST, clocks.get_syscore());
+
+    loop {
+        delay.try_delay_ms(200u8).unwrap();
+        led.set_high();
+        delay.try_delay_ms(200u8).unwrap();
+        led.set_low();
+    }
+}

--- a/boards/arduino_due/memory_sam3_4.x
+++ b/boards/arduino_due/memory_sam3_4.x
@@ -1,0 +1,34 @@
+MEMORY
+{
+  /* NOTE 1 K = 1 KiBi = 1024 bytes */
+  /* SAM3?4 models have 2x128KiB, SAM3?8 models have 2x256KiB */
+  FLASH (rx) : ORIGIN = 0x00080000, LENGTH = 512K
+  /* SAM3?4 models have 32+32KiB, SAM3?8 models have 64+32KiB */
+  RAM (rwx) : ORIGIN = 0x20000000, LENGTH = 64K
+}
+
+/* This is where the call stack will be allocated. */
+/* The stack is of the full descending type. */
+/* You may want to use this variable to locate the call stack and static
+   variables in different memory regions. Below is shown the default value */
+/* _stack_start = ORIGIN(RAM) + LENGTH(RAM); */
+
+/* You can use this symbol to customize the location of the .text section */
+/* If omitted the .text section will be placed right after the .vector_table
+   section */
+/* This is required only on microcontrollers that store some configuration right
+   after the vector table */
+/* _stext = ORIGIN(FLASH) + 0x400; */
+
+/* Example of putting non-initialized variables into custom RAM locations. */
+/* This assumes you have defined a region RAM2 above, and in the Rust
+   sources added the attribute `#[link_section = ".ram2bss"]` to the data
+   you want to place there. */
+/* Note that the section will not be zero-initialized by the runtime! */
+/* SECTIONS {
+     .ram2bss (NOLOAD) : ALIGN(4) {
+       *(.ram2bss);
+       . = ALIGN(4);
+     } > RAM2
+   } INSERT AFTER .bss;
+*/

--- a/boards/arduino_due/memory_sam3_8.x
+++ b/boards/arduino_due/memory_sam3_8.x
@@ -1,0 +1,34 @@
+MEMORY
+{
+  /* NOTE 1 K = 1 KiBi = 1024 bytes */
+  /* SAM3?4 models have 2x128KiB, SAM3?8 models have 2x256KiB */
+  FLASH (rx) : ORIGIN = 0x00080000, LENGTH = 512K
+  /* SAM3?4 models have 32+32KiB, SAM3?8 models have 64+32KiB */
+  RAM (rwx) : ORIGIN = 0x20000000, LENGTH = 64K
+}
+
+/* This is where the call stack will be allocated. */
+/* The stack is of the full descending type. */
+/* You may want to use this variable to locate the call stack and static
+   variables in different memory regions. Below is shown the default value */
+/* _stack_start = ORIGIN(RAM) + LENGTH(RAM); */
+
+/* You can use this symbol to customize the location of the .text section */
+/* If omitted the .text section will be placed right after the .vector_table
+   section */
+/* This is required only on microcontrollers that store some configuration right
+   after the vector table */
+/* _stext = ORIGIN(FLASH) + 0x400; */
+
+/* Example of putting non-initialized variables into custom RAM locations. */
+/* This assumes you have defined a region RAM2 above, and in the Rust
+   sources added the attribute `#[link_section = ".ram2bss"]` to the data
+   you want to place there. */
+/* Note that the section will not be zero-initialized by the runtime! */
+/* SECTIONS {
+     .ram2bss (NOLOAD) : ALIGN(4) {
+       *(.ram2bss);
+       . = ALIGN(4);
+     } > RAM2
+   } INSERT AFTER .bss;
+*/

--- a/boards/arduino_due/src/lib.rs
+++ b/boards/arduino_due/src/lib.rs
@@ -268,4 +268,3 @@ define_pins!(
     /// USB VBOF
     pin usb_vbof = b : 10,
 );
-

--- a/boards/arduino_due/src/lib.rs
+++ b/boards/arduino_due/src/lib.rs
@@ -1,0 +1,271 @@
+#![no_std]
+
+pub use atsam3xa_hal as hal;
+pub use hal::target_device as pac;
+
+pub use hal::prelude;
+
+#[cfg(feature = "rt")]
+extern crate cortex_m_rt;
+
+#[cfg(feature = "rt")]
+pub use cortex_m_rt::entry;
+
+#[cfg(feature = "panic_halt")]
+pub extern crate panic_halt;
+
+use hal::define_pins;
+
+// The docs could be further improved with details of the specific channels etc
+define_pins!(
+    /// Maps the pins to their arduino names and the numbers printed on the board.
+    /// Information from: <https://github.com/arduino/ArduinoCore-sam/blob/master/variants/arduino_due_x/variant.cpp>
+    struct Pins,
+
+    /// Digital 0, UART RX0 (UART/Serial0)
+    pin d0_rx0 = a : 8,
+
+    /// Digital 1, UART TX0 (UART/Serial0)
+    pin d1_tx0 = a : 9,
+
+    /// Digital 2, TIOA0
+    pin d2_tioa0 = b : 25,
+
+    /// Digital 3, TIOA7
+    pin d3_tioa7 = c : 28,
+
+    /// Digital 4, TIOB6
+    pin d4_tiob6 = c : 26,
+
+    /// Digital 5, TIOA6
+    pin d5_tioa6 = c : 25,
+
+    /// Digital 6, PWML7
+    pin d6_pwml7 = c : 24,
+
+    /// Digital 7, PWML6
+    pin d7_pwml6 = c : 23,
+
+    /// Digital 8, PWML5
+    pin d8_pwml5 = c : 22,
+
+    /// Digital 9, PWML4
+    pin d9_pwml4 = c : 21,
+
+    /// Digital 10, NPCS0
+    pin d10_npcs0 = a : 28,
+
+    /// Digital 11, TIOA8
+    pin d11_tioa8 = d : 7,
+
+    /// Digital 12, TIOB8
+    pin d12_tiob8 = d : 8,
+
+    /// Digital 13 (shared with `led_l`), TIOB0
+    pin d13_tiob0 = b : 27,
+
+    /// L (AMBER LED) (shared with `d13_tiob0`)
+    pin led_l = b : 27,
+
+    /// Digital 14, TX3 (USART3/Serial3)
+    pin d14_tx3 = d : 4,
+
+    /// Digital 15, RX3 (USART3/Serial3)
+    pin d15_rx3 = d : 5,
+
+    /// Digital 16, TX2 (USART1/Serial2)
+    pin d16_tx2 = a : 13,
+
+    /// Digital 17, RX2 (USART1/Serial2)
+    pin d17_rx2 = a : 12,
+
+    /// Digital 18, TX1 (USART0/Serial1)
+    pin d18_tx1 = a : 11,
+
+    /// Digital 19, RX1 (USART0/Serial1)
+    pin d19_rx1 = a : 10,
+
+    /// Digital 20, SDA0, TWD1
+    pin d20_sda0_twd1 = b : 12,
+
+    /// Digital 21, SCL0, TWCK1
+    pin d21_scl0_twck1 = b : 13,
+
+    /// Digital 22
+    pin d22 = b : 26,
+
+    /// Digital 23
+    pin d23 = a : 14,
+
+    /// Digital 24
+    pin d24 = a : 15,
+
+    /// Digital 25
+    pin d25 = d : 0,
+
+    /// Digital 26
+    pin d26 = d : 1,
+
+    /// Digital 27
+    pin d27 = d : 2,
+
+    /// Digital 28
+    pin d28 = d : 3,
+
+    /// Digital 29
+    pin d29 = d : 6,
+
+    /// Digital 30
+    pin d30 = d : 9,
+
+    /// Digital 31
+    pin d31 = a : 7,
+
+    /// Digital 32
+    pin d32 = d : 10,
+
+    /// Digital 33
+    pin d33 = c : 1,
+
+    /// Digital 34
+    pin d34 = c : 2,
+
+    /// Digital 35
+    pin d35 = c : 3,
+
+    /// Digital 36
+    pin d36 = c : 4,
+
+    /// Digital 37
+    pin d37 = c : 5,
+
+    /// Digital 38
+    pin d38 = c : 6,
+
+    /// Digital 39
+    pin d39 = c : 7,
+
+    /// Digital 40
+    pin d40 = c : 8,
+
+    /// Digital 41
+    pin d41 = c : 9,
+
+    /// Digital 42
+    pin d42 = a : 19,
+
+    /// Digital 43
+    pin d43 = a : 20,
+
+    /// Digital 44
+    pin d44 = c : 19,
+
+    /// Digital 45
+    pin d45 = c : 18,
+
+    /// Digital 46
+    pin d46 = c : 17,
+
+    /// Digital 47
+    pin d47 = c : 16,
+
+    /// Digital 48
+    pin d48 = c : 15,
+
+    /// Digital 49
+    pin d49 = c : 14,
+
+    /// Digital 50
+    pin d50 = c : 13,
+
+    /// Digital 51
+    pin d51 = c : 12,
+
+    /// Digital 52
+    pin d52 = b : 21,
+
+    /// Digital 53
+    pin d53 = b : 14,
+
+    /// Analog 0
+    pin a0 = a : 16,
+
+    /// Analog 1
+    pin a1 = a : 24,
+
+    /// Analog 2
+    pin a2 = a : 23,
+
+    /// Analog 3
+    pin a3 = a : 22,
+
+    /// Analog 4, TIOB2
+    pin a4_tiob2 = a : 6,
+
+    /// Analog 5
+    pin a5 = a : 4,
+
+    /// Analog 6, TIOB1
+    pin a6_tiob1 = a : 3,
+
+    /// Analog 7, TIOA1
+    pin a7_tioa1 = a : 2,
+
+    /// Analog 8
+    pin a8 = b : 17,
+
+    /// Analog 9
+    pin a9 = b : 18,
+
+    /// Analog 10
+    pin a10 = b : 19,
+
+    /// Analog 11
+    pin a11 = b : 20,
+
+    /// Analog 12, DAC0
+    pin a12_dac0 = b : 15,
+
+    /// Analog 13, DAC1
+    pin a13_dac1 = b : 16,
+
+    /// Analog 14, CANRX
+    pin a14_canrx = a : 1,
+
+    /// Analog 15, CANTX
+    pin a15_cantx = a : 0,
+
+    /// SDA1, TWD0
+    pin sda1_twd0 = a : 17,
+
+    /// SCL1, TWCK0
+    pin scl1_twck0 = a : 18,
+
+    /// RX (AMBER LED)
+    pin led_rx = c : 30,
+
+    /// TX (AMBER LED)
+    pin led_tx = a : 21,
+
+    /// MISO
+    pin miso = a : 25,
+
+    /// MOSI
+    pin mosi = a : 26,
+
+    /// SCLK
+    pin sclk = a : 27,
+
+    /// NPCS0
+    pin npcs0 = a : 28,
+
+    /// NPCS3 (unconnected)
+    pin npcs3 = b : 23,
+
+    /// USB ID
+    pin usb_id = b : 11,
+
+    /// USB VBOF
+    pin usb_vbof = b : 10,
+);
+

--- a/hal/Cargo.toml
+++ b/hal/Cargo.toml
@@ -26,10 +26,21 @@ atsam3x8e = { version = "", path = "../pac/atsam3x8e", optional = true }
 atsam3x8h = { version = "", path = "../pac/atsam3x8h", optional = true }
 
 [features]
-atsam3a4c-rt = ["atsam3a4c/rt"]
-atsam3a8c-rt = ["atsam3a8c/rt"]
-atsam3x4c-rt = ["atsam3x4c/rt"]
-atsam3x4e-rt = ["atsam3x4e/rt"]
-atsam3x8c-rt = ["atsam3x8c/rt"]
-atsam3x8e-rt = ["atsam3x8e/rt"]
-atsam3x8h-rt = ["atsam3x8h/rt"]
+sam3_4 = [] # feature for shared traits between sam3a4c, sam3x4c, sam3x4e
+sam3_8 = [] # feature for shared traits between sam3a8c, sam3x8c, sam3x8e, sam3x8h
+sam3_c = [] # feature for shared traits between sam3a4c, sam3a8c, sam3x4c, sam3x8c
+sam3_e = [] # feature for shared traits between sam3x4e, sam3x8e
+sam3a4c = ["atsam3a4c", "sam3_4", "sam3_c"]
+sam3a4c-rt = ["atsam3a4c/rt", "sam3a4c"]
+sam3a8c = ["atsam3a8c", "sam3_8", "sam3_c"]
+sam3a8c-rt = ["atsam3a8c/rt", "sam3a8c"]
+sam3x4c = ["atsam3x4c", "sam3_4", "sam3_c"]
+sam3x4c-rt = ["atsam3x4c/rt", "sam3x4c"]
+sam3x4e = ["atsam3x4e", "sam3_4", "sam3_e"]
+sam3x4e-rt = ["atsam3x4e/rt", "sam3x4e"]
+sam3x8c = ["atsam3x8c", "sam3_8", "sam3_c"]
+sam3x8c-rt = ["atsam3x8c/rt", "sam3x8c"]
+sam3x8e = ["atsam3x8e", "sam3_e", "sam3_e"]
+sam3x8e-rt = ["atsam3x8e/rt", "sam3x8e"]
+sam3x8h = ["atsam3x8h", "sam3_8"]
+sam3x8h-rt = ["atsam3x8h/rt", "sam3x8h"]

--- a/hal/build.sh
+++ b/hal/build.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
+DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ACTION=${1:-build}
-for mcutype in $(ls ../pac/ | grep '^atsam3') ; do
-    echo -e "\n--==[ ${mcutype} ] ]==--" 
-    cargo ${ACTION} --features ${mcutype}
+for mcutype in $(ls ${DIR}/../pac/ | grep '^atsam3') ; do
+    echo -e "\n--==[ ${mcutype} ]==--" 
+    cargo ${ACTION} --features ${mcutype:2}
 done
 

--- a/hal/src/bus.rs
+++ b/hal/src/bus.rs
@@ -35,8 +35,7 @@ impl BusInterconnect {
     /// Toggle off the sysio configurations for pins, enabling their peripheral
     /// configurations instead.
     pub fn disable_sysio(&mut self) {
-        self.ccfg_sysio
-            .modify(|_, w| w.sysio12().clear_bit());
+        self.ccfg_sysio.modify(|_, w| w.sysio12().clear_bit());
     }
 
     /// Toggle on the sysio configurations for pins, disabling their peripheral

--- a/hal/src/clock.rs
+++ b/hal/src/clock.rs
@@ -542,7 +542,7 @@ impl core::ops::DerefMut for SystemClocks {
 impl SystemClocks {
     /// Select the specified slow clock oscillator, and clock the system to run
     /// at that frequency.
-    pub fn with_slow_clk_32kosc(pmc: PMC, supc: SUPC, use_external_crystal: bool) -> Self {
+    pub fn with_slow_clk(pmc: PMC, supc: SUPC, use_external_crystal: bool) -> Self {
         let mut clk = Self {
             state: State { pmc, supc },
         };

--- a/hal/src/clock.rs
+++ b/hal/src/clock.rs
@@ -417,9 +417,7 @@ impl State {
             PeripheralID::Id06Eefc0 => (), // Clock not under PMC control
             PeripheralID::Id07Eefc1 => (), // Clock not under PMC control
             PeripheralID::Id08Uart => self.pmc_pcer0.write_with_zero(|w| w.pid8().set_bit()),
-            PeripheralID::Id09SmcSdramc => {
-                self.pmc_pcer0.write_with_zero(|w| w.pid9().set_bit())
-            }
+            PeripheralID::Id09SmcSdramc => self.pmc_pcer0.write_with_zero(|w| w.pid9().set_bit()),
             PeripheralID::Id10Sdramc => self.pmc_pcer0.write_with_zero(|w| w.pid10().set_bit()),
             PeripheralID::Id11PioA => self.pmc_pcer0.write_with_zero(|w| w.pid11().set_bit()),
             PeripheralID::Id12PioB => self.pmc_pcer0.write_with_zero(|w| w.pid12().set_bit()),
@@ -472,9 +470,7 @@ impl State {
             PeripheralID::Id06Eefc0 => (), // Clock not under PMC control
             PeripheralID::Id07Eefc1 => (), // Clock not under PMC control
             PeripheralID::Id08Uart => self.pmc_pcdr0.write_with_zero(|w| w.pid8().set_bit()),
-            PeripheralID::Id09SmcSdramc => {
-                self.pmc_pcdr0.write_with_zero(|w| w.pid9().set_bit())
-            }
+            PeripheralID::Id09SmcSdramc => self.pmc_pcdr0.write_with_zero(|w| w.pid9().set_bit()),
             PeripheralID::Id10Sdramc => self.pmc_pcdr0.write_with_zero(|w| w.pid10().set_bit()),
             PeripheralID::Id11PioA => self.pmc_pcdr0.write_with_zero(|w| w.pid11().set_bit()),
             PeripheralID::Id12PioB => self.pmc_pcdr0.write_with_zero(|w| w.pid12().set_bit()),

--- a/hal/src/gpio.rs
+++ b/hal/src/gpio.rs
@@ -2,20 +2,15 @@
 use crate::hal::digital::{InputPin, OutputPin, StatefulOutputPin, ToggleableOutputPin};
 
 // SAM3A4C, SAM3A8C, SAM3X4C, and SAM3X8C (100-pin) only have PIOA-PIOB
-#[cfg(any(
-    feature = "atsam3a4c",
-    feature = "atsam3a8c",
-    feature = "atsam3x4c",
-    feature = "atsam3x8c"
-))]
+#[cfg(feature = "sam3_c")]
 use crate::target_device::{PIOA, PIOB};
 
 // SAM3X4E and SAM3X8E (144-pin) have PIOA-PIOD
-#[cfg(any(feature = "atsam3x4e", feature = "atsam3x8e"))]
+#[cfg(feature = "sam3_e")]
 use crate::target_device::{PIOA, PIOB, PIOC, PIOD};
 
 // SAM3X8H has 217 pins and PIOA-PIOF
-#[cfg(feature = "atsam3x8h")]
+#[cfg(feature = "sam3x8h")]
 use crate::target_device::{PIOA, PIOB, PIOC, PIOD, PIOE, PIOF};
 
 use core::marker::PhantomData;
@@ -356,7 +351,7 @@ pio_group!(
 );
 
 // PIOC pins 0-30 on the atsam3x4e, atsam3x8e, and atsam3x8h targets
-#[cfg(any(feature = "atsam3x4e", feature = "atsam3x8e", feature = "atsam3x8h"))]
+#[cfg(any(feature = "sam3_e", feature = "sam3x8h"))]
 pio_group!(
     c,
     13,
@@ -368,11 +363,11 @@ pio_group!(
 
 // PIOD is not supported by the atsam3x?c targets, and only has pins 0-10 on
 // the atsam3x?e targets
-#[cfg(any(feature = "atsam3x4e", feature = "atsam3x8e"))]
+#[cfg(feature = "sam3_e")]
 pio_group!(d, 14, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,]);
 
 // PIOD has pins 0-30 on the atsam3x8h target
-#[cfg(feature = "atsam3x8h")]
+#[cfg(feature = "sam3x8h")]
 pio_group!(
     d,
     14,
@@ -383,7 +378,7 @@ pio_group!(
 );
 
 // PIOE has pins 0-31 on the atsam3x8h target
-#[cfg(feature = "atsam3x8h")]
+#[cfg(feature = "sam3x8h")]
 pio_group!(
     e,
     15,
@@ -394,7 +389,7 @@ pio_group!(
 );
 
 // PIOF has pins 0-6 on the atsam3x8h target
-#[cfg(feature = "atsam3x8h")]
+#[cfg(feature = "sam3x8h")]
 pio_group!(f, 16, [0, 1, 2, 3, 4, 5, 6,]);
 
 /// This macro is a helper for defining a `Pins` type in a board support
@@ -434,7 +429,7 @@ pub struct $Type {
 }
 
 impl $Type {
-    #[cfg(any(feature = "atsam3a4c", feature = "atsam3a8c", feature = "atsam3x4c", feature = "atsam3x8c"))]
+    #[cfg(feature = "sam3_c")]
     /// Returns the pins for the device
     pub fn new(pioa: $crate::target_device::PIOA, piob: $crate::target_device::PIOB) -> Self {
         let pa = $crate::gpio::PioGroup::from(pioa);
@@ -449,7 +444,7 @@ impl $Type {
         }
     }
 
-    #[cfg(any(feature = "atsam3x4e", feature = "atsam3x8e"))]
+    #[cfg(feature = "sam3_e")]
     /// Returns the pins for the device
     pub fn new(pioa: $crate::target_device::PIOA, piob: $crate::target_device::PIOB, pioc: $crate::target_device::PIOC, piod: $crate::target_device::PIOD) -> Self {
         let pa = $crate::gpio::PioGroup::from(pioa);
@@ -468,7 +463,7 @@ impl $Type {
         }
     }
 
-    #[cfg(feature = "atsam3x8h")]
+    #[cfg(feature = "sam3x8h")]
     /// Returns the pins for the device
     pub fn new(pioa: $crate::target_device::PIOA, piob: $crate::target_device::PIOB, pioc: $crate::target_device::PIOC, piod: $crate::target_device::PIOD,  pioe: $crate::target_device::PIOE, piof: $crate::target_device::PIOF) -> Self {
         let pa = $crate::gpio::PioGroup::from(pioa);

--- a/hal/src/gpio.rs
+++ b/hal/src/gpio.rs
@@ -427,15 +427,17 @@ pub struct $Type {
         pub $name: $crate::gpio::[<P $pio_group $pin_ident>]<$crate::gpio::Unconfigured>
     ),+
 }
+} // end paste
 
 impl $Type {
+    $crate::paste! {
     #[cfg(feature = "sam3_c")]
     /// Returns the pins for the device
     pub fn new(pioa: $crate::target_device::PIOA, piob: $crate::target_device::PIOB) -> Self {
         let pa = $crate::gpio::PioGroup::from(pioa);
         let pb = $crate::gpio::PioGroup::from(piob);
         $(
-        let $name: [<p $pio_group>].[<p $pin_ident>]();
+        let $name = [<p $pio_group>].[<p $pin_ident>]();
         )+
         $Type {
             pa,
@@ -443,7 +445,9 @@ impl $Type {
             $($name),+,
         }
     }
+    } // end paste
 
+    $crate::paste! {
     #[cfg(feature = "sam3_e")]
     /// Returns the pins for the device
     pub fn new(pioa: $crate::target_device::PIOA, piob: $crate::target_device::PIOB, pioc: $crate::target_device::PIOC, piod: $crate::target_device::PIOD) -> Self {
@@ -462,7 +466,9 @@ impl $Type {
             $($name),+,
         }
     }
+    } // end paste
 
+    $crate::paste! {
     #[cfg(feature = "sam3x8h")]
     /// Returns the pins for the device
     pub fn new(pioa: $crate::target_device::PIOA, piob: $crate::target_device::PIOB, pioc: $crate::target_device::PIOC, piod: $crate::target_device::PIOD,  pioe: $crate::target_device::PIOE, piof: $crate::target_device::PIOF) -> Self {
@@ -485,7 +491,7 @@ impl $Type {
             $($name),+,
         }
     }
+    } // end paste
 }
-} // end paste
 
 }}

--- a/hal/src/gpio.rs
+++ b/hal/src/gpio.rs
@@ -2,7 +2,12 @@
 use crate::hal::digital::{InputPin, OutputPin, StatefulOutputPin, ToggleableOutputPin};
 
 // SAM3A4C, SAM3A8C, SAM3X4C, and SAM3X8C (100-pin) only have PIOA-PIOB
-#[cfg(any(feature = "atsam3a4c", feature = "atsam3a8c", feature = "atsam3x4c", feature = "atsam3x8c"))]
+#[cfg(any(
+    feature = "atsam3a4c",
+    feature = "atsam3a8c",
+    feature = "atsam3x4c",
+    feature = "atsam3x8c"
+))]
 use crate::target_device::{PIOA, PIOB};
 
 // SAM3X4E and SAM3X8E (144-pin) have PIOA-PIOD
@@ -14,7 +19,6 @@ use crate::target_device::{PIOA, PIOB, PIOC, PIOD};
 use crate::target_device::{PIOA, PIOB, PIOC, PIOD, PIOE, PIOF};
 
 use core::marker::PhantomData;
-use paste::paste;
 
 /// PIO controller configuration register block.
 pub struct PioGroup<PIOn> {
@@ -76,14 +80,14 @@ macro_rules! pin {
         $pin_ident:ident,
         $pin_no:expr
     ) => {
-        paste! {
+        crate::paste! {
         /// Represents the IO pin with the matching name.
         pub struct $PinType<MODE> {
             _mode: PhantomData<MODE>,
         }
         } // end paste
 
-        paste! {
+        crate::paste! {
         /// Represents an unconfigured IO pin.
         pub type [<Unconfigured $PinType>] = $PinType<Unconfigured>;
         impl Default for [<Unconfigured $PinType>] {
@@ -105,7 +109,7 @@ macro_rules! pin {
         impl<MODE> $PinType<MODE> {
             /// Configures the pin to operate as a floating input
             pub fn into_floating_input(self) -> $PinType<Input<Floating>> {
-                paste! {
+                crate::paste! {
                 // Enable PIO (not peripheral) mode
                 unsafe {(*$group::ptr()).per.write_with_zero(|w| w.[<p $pin_no>]().set_bit());}
                 // Disable output mode (input)
@@ -118,7 +122,7 @@ macro_rules! pin {
 
             /// Configures the pin to operate as a pulled-up input
             pub fn into_pull_up_input(self) -> $PinType<Input<PullUp>> {
-                paste! {
+                crate::paste! {
                 // Enable PIO (not peripheral) mode
                 unsafe {(*$group::ptr()).per.write_with_zero(|w| w.[<p $pin_no>]().set_bit());}
                 // Disable output mode (input)
@@ -131,7 +135,7 @@ macro_rules! pin {
 
             /// Configures the pin to operate as an open-drain output
             pub fn into_open_drain_output(self) -> $PinType<Output<OpenDrain>> {
-                paste! {
+                crate::paste! {
                 // Enable PIO (not peripheral) mode
                 unsafe {(*$group::ptr()).per.write_with_zero(|w| w.[<p $pin_no>]().set_bit());}
                 // Enable output mode
@@ -144,7 +148,7 @@ macro_rules! pin {
 
             /// Configures the pin to operate as an push-pull output
             pub fn into_push_pull_output(self) -> $PinType<Output<PushPull>> {
-                paste! {
+                crate::paste! {
                 // Enable PIO (not peripheral) mode
                 unsafe {(*$group::ptr()).per.write_with_zero(|w| w.[<p $pin_no>]().set_bit());}
                 // Enable output mode
@@ -159,7 +163,7 @@ macro_rules! pin {
 
             /// Configures the pin to function as the primary (A) attached peripheral.
             pub fn into_peripheral_a(self) -> $PinType<PfA> {
-                paste! {
+                crate::paste! {
                 // Disable PIO (enable peripheral) mode
                 unsafe {(*$group::ptr()).pdr.write_with_zero(|w| w.[<p $pin_no>]().set_bit());}
                 // Select Peripheral A (0 -> A, 1 -> B)
@@ -170,7 +174,7 @@ macro_rules! pin {
 
             /// Configures the pin to function as the alternate (B) attached peripheral.
             pub fn into_peripheral_b(self) -> $PinType<PfB> {
-                paste! {
+                crate::paste! {
                 // Disable PIO (enable peripheral) mode
                 unsafe {(*$group::ptr()).pdr.write_with_zero(|w| w.[<p $pin_no>]().set_bit());}
                 // Select Peripheral B (0 -> A, 1 -> B)
@@ -201,7 +205,7 @@ macro_rules! pin {
             }
 
             fn set_high_impl(&mut self) {
-                paste! {
+                crate::paste! {
                 unsafe {(*$group::ptr()).sodr.write_with_zero(|w| w.[<p $pin_no>]().bit(true));}
                 } // end paste
             }
@@ -212,7 +216,7 @@ macro_rules! pin {
             }
 
             fn set_low_impl(&mut self) {
-                paste! {
+                crate::paste! {
                 unsafe {(*$group::ptr()).codr.write_with_zero(|w| w.[<p $pin_no>]().bit(true));}
                 } // end paste
             }
@@ -256,7 +260,7 @@ macro_rules! pin {
             /// If $group is not currently clocked, this will return the value from
             /// when it was last clocked.
             pub fn is_high(&self) -> bool {
-                paste! {
+                crate::paste! {
                 unsafe {(*$group::ptr()).pdsr.read().[<p $pin_no>]().bits()}
                 } // end paste
             }
@@ -286,13 +290,20 @@ macro_rules! pin {
 macro_rules! pio_group {
     (
         $group_id:ident,
+        $peripheral_id:expr,
         [
           $($pin_no:expr,)+
         ]
     ) => {
 
-paste! {
+crate::paste! {
 impl PioGroup<[<PIO $group_id:upper>]> {
+    /// Return the Peripheral ID for the PIOF Controller, used for controlling
+    /// clocks and interrupts.
+    pub fn peripheral_id() -> $crate::clock::PeripheralID {
+        $crate::clock::PeripheralID::[<Id $peripheral_id Pio $group_id:upper>]
+    }
+
     /// Instantiate a representation of a PIO group, providing an interface
     /// to all the pins it controls.
     pub fn new(group: [<PIO $group_id:upper>]) -> Self {
@@ -300,7 +311,6 @@ impl PioGroup<[<PIO $group_id:upper>]> {
             group,
         }
     }
-
 
     $(
     /// Access the configuration and state of the pin of this name on this PIO
@@ -328,6 +338,7 @@ $(
 // PIOA has the same pin set among all targets
 pio_group!(
     a,
+    11,
     [
         0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
         25, 26, 27, 28, 29, 30, 31,
@@ -337,6 +348,7 @@ pio_group!(
 // PIOB has the same pin set among all targets
 pio_group!(
     b,
+    12,
     [
         0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
         25, 26, 27, 28, 29, 30, 31,
@@ -347,6 +359,7 @@ pio_group!(
 #[cfg(any(feature = "atsam3x4e", feature = "atsam3x8e", feature = "atsam3x8h"))]
 pio_group!(
     c,
+    13,
     [
         0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
         25, 26, 27, 28, 29, 30,
@@ -356,12 +369,13 @@ pio_group!(
 // PIOD is not supported by the atsam3x?c targets, and only has pins 0-10 on
 // the atsam3x?e targets
 #[cfg(any(feature = "atsam3x4e", feature = "atsam3x8e"))]
-pio_group!(d, [ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, ]);
+pio_group!(d, 14, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,]);
 
 // PIOD has pins 0-30 on the atsam3x8h target
 #[cfg(feature = "atsam3x8h")]
 pio_group!(
     d,
+    14,
     [
         0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
         25, 26, 27, 28, 29, 30,
@@ -372,6 +386,7 @@ pio_group!(
 #[cfg(feature = "atsam3x8h")]
 pio_group!(
     e,
+    15,
     [
         0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
         25, 26, 27, 28, 29, 30, 31,
@@ -380,9 +395,102 @@ pio_group!(
 
 // PIOF has pins 0-6 on the atsam3x8h target
 #[cfg(feature = "atsam3x8h")]
-pio_group!(
-    f,
-    [
-        0, 1, 2, 3, 4, 5, 6,
-    ]
-);
+pio_group!(f, 16, [0, 1, 2, 3, 4, 5, 6,]);
+
+/// This macro is a helper for defining a `Pins` type in a board support
+/// crate.  This type is used to provide more meaningful aliases for the
+/// various GPIO pins for a given board.
+#[macro_export]
+macro_rules! define_pins {
+    (
+        $(#[$topattr:meta])* struct $Type:ident,
+        $( $(#[$attr:meta])* pin $name:ident = $pio_group:ident : $pin_ident:expr),+ ,
+    ) => {
+
+$crate::paste! {
+$(#[$topattr])*
+pub struct $Type {
+    /// Opaque reference to PIO controller A
+    pub pa: $crate::gpio::PioGroup<$crate::target_device::PIOA>,
+    /// Opaque reference to PIO controller B
+    pub pb: $crate::gpio::PioGroup<$crate::target_device::PIOB>,
+    /// Opaque reference to PIO controller C
+    #[cfg(any(feature = "sam3_e", feature = "sam3x8h"))]
+    pub pc: $crate::gpio::PioGroup<$crate::target_device::PIOC>,
+    /// Opaque reference to PIO controller D
+    #[cfg(any(feature = "sam3_e", feature = "sam3x8h"))]
+    pub pd: $crate::gpio::PioGroup<$crate::target_device::PIOD>,
+    /// Opaque reference to PIO controller E
+    #[cfg(feature = "sam3x8h")]
+    pub pe: $crate::gpio::PioGroup<$crate::target_device::PIOE>,
+    /// Opaque reference to PIO controller F
+    #[cfg(feature = "sam3x8h")]
+    pub pf: $crate::gpio::PioGroup<$crate::target_device::PIOF>,
+
+    $(
+        $(#[$attr])*
+        pub $name: $crate::gpio::[<P $pio_group $pin_ident>]<$crate::gpio::Unconfigured>
+    ),+
+}
+
+impl $Type {
+    #[cfg(any(feature = "atsam3a4c", feature = "atsam3a8c", feature = "atsam3x4c", feature = "atsam3x8c"))]
+    /// Returns the pins for the device
+    pub fn new(pioa: $crate::target_device::PIOA, piob: $crate::target_device::PIOB) -> Self {
+        let pa = $crate::gpio::PioGroup::from(pioa);
+        let pb = $crate::gpio::PioGroup::from(piob);
+        $(
+        let $name: [<p $pio_group>].[<p $pin_ident>]();
+        )+
+        $Type {
+            pa,
+            pb,
+            $($name),+,
+        }
+    }
+
+    #[cfg(any(feature = "atsam3x4e", feature = "atsam3x8e"))]
+    /// Returns the pins for the device
+    pub fn new(pioa: $crate::target_device::PIOA, piob: $crate::target_device::PIOB, pioc: $crate::target_device::PIOC, piod: $crate::target_device::PIOD) -> Self {
+        let pa = $crate::gpio::PioGroup::from(pioa);
+        let pb = $crate::gpio::PioGroup::from(piob);
+        let pc = $crate::gpio::PioGroup::from(pioc);
+        let pd = $crate::gpio::PioGroup::from(piod);
+        $(
+        let $name = [<p $pio_group>].[<p $pin_ident>]();
+        )+
+        $Type {
+            pa,
+            pb,
+            pc,
+            pd,
+            $($name),+,
+        }
+    }
+
+    #[cfg(feature = "atsam3x8h")]
+    /// Returns the pins for the device
+    pub fn new(pioa: $crate::target_device::PIOA, piob: $crate::target_device::PIOB, pioc: $crate::target_device::PIOC, piod: $crate::target_device::PIOD,  pioe: $crate::target_device::PIOE, piof: $crate::target_device::PIOF) -> Self {
+        let pa = $crate::gpio::PioGroup::from(pioa);
+        let pb = $crate::gpio::PioGroup::from(piob);
+        let pc = $crate::gpio::PioGroup::from(pioc);
+        let pd = $crate::gpio::PioGroup::from(piod);
+        let pe = $crate::gpio::PioGroup::from(pioe);
+        let pf = $crate::gpio::PioGroup::from(piof);
+        $(
+        let $name = [<p $pio_group>].[<p $pin_ident>]();
+        )+
+        $Type {
+            pa,
+            pb,
+            pc,
+            pd,
+            pe,
+            pf,
+            $($name),+,
+        }
+    }
+}
+} // end paste
+
+}}

--- a/hal/src/lib.rs
+++ b/hal/src/lib.rs
@@ -29,14 +29,22 @@
 
 pub use paste::paste;
 
+#[cfg(feature = "sam3a4c")]
+pub use atsam3a4c as target_device;
+#[cfg(feature = "sam3a8c")]
+pub use atsam3a8c as target_device;
+#[cfg(feature = "sam3x4c")]
+pub use atsam3x4c as target_device;
+#[cfg(feature = "sam3x4e")]
+pub use atsam3x4e as target_device;
+#[cfg(feature = "sam3x8c")]
+pub use atsam3x8c as target_device;
+#[cfg(feature = "sam3x8e")]
+pub use atsam3x8e as target_device;
+#[cfg(feature = "sam3x8h")]
+pub use atsam3x8h as target_device;
+
 pub use embedded_hal as hal;
-#[cfg(feature = "sam3a4c")] pub use atsam3a4c as target_device;
-#[cfg(feature = "sam3a8c")] pub use atsam3a8c as target_device;
-#[cfg(feature = "sam3x4c")] pub use atsam3x4c as target_device;
-#[cfg(feature = "sam3x4e")] pub use atsam3x4e as target_device;
-#[cfg(feature = "sam3x8c")] pub use atsam3x8c as target_device;
-#[cfg(feature = "sam3x8e")] pub use atsam3x8e as target_device;
-#[cfg(feature = "sam3x8h")] pub use atsam3x8h as target_device;
 
 pub mod bus;
 pub mod clock;

--- a/hal/src/lib.rs
+++ b/hal/src/lib.rs
@@ -30,13 +30,13 @@
 pub use paste::paste;
 
 pub use embedded_hal as hal;
-#[cfg(feature = "atsam3a4c")] pub use atsam3a4c as target_device;
-#[cfg(feature = "atsam3a8c")] pub use atsam3a8c as target_device;
-#[cfg(feature = "atsam3x4c")] pub use atsam3x4c as target_device;
-#[cfg(feature = "atsam3x4e")] pub use atsam3x4e as target_device;
-#[cfg(feature = "atsam3x8c")] pub use atsam3x8c as target_device;
-#[cfg(feature = "atsam3x8e")] pub use atsam3x8e as target_device;
-#[cfg(feature = "atsam3x8h")] pub use atsam3x8h as target_device;
+#[cfg(feature = "sam3a4c")] pub use atsam3a4c as target_device;
+#[cfg(feature = "sam3a8c")] pub use atsam3a8c as target_device;
+#[cfg(feature = "sam3x4c")] pub use atsam3x4c as target_device;
+#[cfg(feature = "sam3x4e")] pub use atsam3x4e as target_device;
+#[cfg(feature = "sam3x8c")] pub use atsam3x8c as target_device;
+#[cfg(feature = "sam3x8e")] pub use atsam3x8e as target_device;
+#[cfg(feature = "sam3x8h")] pub use atsam3x8h as target_device;
 
 pub mod bus;
 pub mod clock;

--- a/hal/src/lib.rs
+++ b/hal/src/lib.rs
@@ -27,6 +27,8 @@
 #![deny(warnings)]
 #![no_std]
 
+pub use paste::paste;
+
 pub use embedded_hal as hal;
 #[cfg(feature = "atsam3a4c")] pub use atsam3a4c as target_device;
 #[cfg(feature = "atsam3a8c")] pub use atsam3a8c as target_device;


### PR DESCRIPTION
To support the addition of this board, hal::gpio was updated with a support macro for providing board-specific pin mappings.

Implementing this feature revealed issues with both SystemClock::with_slow_clk(), as well as with <Pin>::toggle().